### PR TITLE
Revert Python dependency from ^3.7.12 to >=3.7.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ exclude = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7.12"
+python = ">=3.7.11"
 django = ">=3.2.5"
 jsonfield = ">=3.0"
 stripe = ">=2.48.0"


### PR DESCRIPTION
Apparently there is no compelling reason to pin Python to 3.7.12, so this fork reverts to 3.7.11.